### PR TITLE
ci: update actions/checkout to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
   scan:
     needs: lint-and-test


### PR DESCRIPTION
## Summary
update actions/checkout to v4 to use node 20 runtime

v4 release notes: https://github.com/actions/checkout/releases/tag/v4.0.0