### PR TITLE
[WEB3-6101] Remove Github CI Scan check in public repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,12 +9,7 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3
-
-  scan:
-    needs: lint-and-test
-    if: github.event_name == 'pull_request'
-    uses: circlefin/circle-public-github-workflows/.github/workflows/pr-scan.yaml@v1
-
+        
   release-sbom:
     needs: lint-and-test
     if: github.event_name == 'push'


### PR DESCRIPTION
## Summary
Remove the Scan Check from the GitHub CI workflow in the public repository.

## Detail
The scan check has already been performed in the internal repository before being pushed to the public repository. 
As a result, running the scan check again in the public repository is redundant and unnecessary.

**Story:** <https://circlepay.atlassian.net/browse/WEB3-6101>