### PR TITLE
chore: onboard stepsecurity and apply security best practice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,14 @@ on:
 jobs:
   lint-and-test:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+      - name: Harden the runner
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
         with:
-          egress-policy: audit
+          egress-policy: block
+          policy: global-allowed-endpoints-policy
 
       - name: Check out repository code
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,13 @@ jobs:
   lint-and-test:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        with:
+          egress-policy: audit
+
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         
   release-sbom:
     needs: lint-and-test


### PR DESCRIPTION
This pull request introduces security enhancements to the CI workflow by hardening the runner and specifying permissions. The most important changes are:

Security improvements to the CI workflow:

* Added the `step-security/harden-runner` action to the `lint-and-test` job in `.github/workflows/ci.yml` to block egress traffic and enforce a global allowed endpoints policy, improving runner security.
* Explicitly set the `id-token: write` permission for the `lint-and-test` job, aligning with best practices for least privilege.

Dependency version pinning:

* Updated the `actions/checkout` action to use a specific commit hash (`v3.6.0`) instead of a floating version, ensuring reproducibility and security.