### PR TITLE
chore(stepsecurity): update workflows to use custom hosted runners with built-in StepSecurity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,10 @@ on:
     branches: [master]
 jobs:
   lint-and-test:
-    runs-on: ubuntu-latest
+    runs-on: github-hosted-small
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         
   release-sbom:
     needs: lint-and-test


### PR DESCRIPTION
## Summary
This PR updates GitHub Actions workflows to use custom hosted runners that have StepSecurity built-in, removing the need for the explicit StepSecurity harden-runner action.

## What Changed
- Removed step-security/harden-runner action steps (no longer needed as StepSecurity is built into custom runners)
- Removed id-token: write permissions (no longer needed without the StepSecurity action)
- Updated runs-on from ubuntu-latest to github-hosted-small (custom runners with built-in StepSecurity)
- Converted non-circlefin action versions to commit SHAs with version comments for security pinning (e.g., actions/checkout@abc123 # v3.6.0)
- circlefin GitHub actions remain unchanged

## Purpose
Our custom hosted runners (github-hosted-small) now have StepSecurity built-in at the runner level, so we no longer need to add it as an explicit step in each workflow. This simplifies our workflows while maintaining the same security posture.

## Testing
- All workflow syntax changes have been validated
- No functional changes to workflow behavior
- StepSecurity protection is maintained via the custom runners
- Review the diff to ensure only intended changes occurred